### PR TITLE
Prune older domains

### DIFF
--- a/IOCs/crowdstrike-day2-ioc.txt
+++ b/IOCs/crowdstrike-day2-ioc.txt
@@ -17,9 +17,6 @@ crowdstrikeclaim[.]com
 crowdstrike-falcon[.]online
 crowdstrike[.]black
 crowdstrikefix[.]com
-crowdstrik[.]e-helpdesk.com
-crowdstrike[.]outage.info
-crowdstrikeou[.]tage.info
 iscrowdstrikedown[.]com
 crowdstrikedown[.]com
 crowdstrike-bluescreen[.]com
@@ -51,13 +48,6 @@ crowdstrikerescue[.]org
 crowdstrikesucks[.]com
 crowdstrikesupport[.]com
 crowdstrikesupport[.]info
-crowdstrik[.]e-falcon.com
-crowdstrike-falc[.]on.com
-crowdstrike-fa[.]lcon.site
-crowdstrike[.]outage.com
-crowdstrikeo[.]utage.com
-crowdstrike-b[.]sod.com
-crowdstrik[.]e-fix.com
 crowdstrike-helpdesk[.]com
 crowdstrike0day[.]com
 crowdstrikebluescreen[.]com
@@ -169,8 +159,6 @@ crowdstrike[.]fail
 crowdstrike[.]help
 crowdstrikedown[.]site
 crowdstrikeoutage[.]info
-crowdstr[.]ike.blue
-crowd[.]strike.blue
 crowdstrike-bsod[.]co
 crowdstrike-bsod[.]com
 crowdstrike[.]es

--- a/IOCs/crowdstrike-day2-ioc.txt
+++ b/IOCs/crowdstrike-day2-ioc.txt
@@ -53,7 +53,6 @@ crowdstrikesupport[.]com
 crowdstrikesupport[.]info
 crowdstrik[.]e-falcon.com
 crowdstrike-falc[.]on.com
-crowdstrike-fal[.]con.com
 crowdstrike-fa[.]lcon.site
 crowdstrike[.]outage.com
 crowdstrikeo[.]utage.com


### PR DESCRIPTION
This removes entries from registered domains that were registered before July 2024. It's not clear how these ended up here but they appear to be a mistake. 

I became aware of a problem via a note from a vendor saying one particular domain (con.com) was being banned due to inappropriate use. My read of the [Akamai blog entry](https://www.akamai.com/blog/security-research/2024-july-crowdstrike-bsod-domains-what-could-come-next) is that this file should contain domains registered on or after July 19th. This does not actually appear to be the case for several domains.

The domains I've removed appear to all contain wildcard records which cover these specific domain queries. I'm guessing that the discovery mechanism assumed that valid DNS entries for these "crowdstrike"-containing names must have been created specifically for this incident.